### PR TITLE
Skip Tenant object during clusterctl move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ managers: ## Build all managers
 
 .PHONY: clusterctl
 clusterctl: ## Build clusterctl binary
-	go build -ldflags "$(LDFLAGS)" -o bin/clusterctl sigs.k8s.io/cluster-api/cmd/clusterctl
+	env CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/clusterctl sigs.k8s.io/cluster-api/cmd/clusterctl
 
 $(KUSTOMIZE): $(TOOLS_DIR)/go.mod # Build kustomize from tools folder.
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/kustomize sigs.k8s.io/kustomize/kustomize/v3

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -285,7 +285,7 @@ func getMoveSequence(graph *objectGraph) *moveSequence {
 			// otherwise skip it (the node will be re-processed in the next group).
 			ownersInPlace := true
 			for owner := range n.owners {
-				if !moveSequence.hasNode(owner) {
+				if !moveSequence.hasNode(owner) && owner.identity.Kind != "Tenant" {
 					ownersInPlace = false
 					break
 				}
@@ -499,6 +499,10 @@ func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy) erro
 	if len(nodeToCreate.owners) > 0 {
 		ownerRefs := []metav1.OwnerReference{}
 		for ownerNode := range nodeToCreate.owners {
+			if ownerNode.identity.Kind == "Tenant" {
+				// Skip owner reference to Tenant object
+				continue
+			}
 			ownerRef := metav1.OwnerReference{
 				APIVersion: ownerNode.identity.APIVersion,
 				Kind:       ownerNode.identity.Kind,


### PR DESCRIPTION
🌱 During **clusterctl move** all the objects related to Cluster object (linked with OwnerReference chains) are marked and moved together. We want to skip **Tenant** object from such tagging and avoid moving that:
